### PR TITLE
Small Update for links in Data Publication Services

### DIFF
--- a/GlobusWorldTour/Data_Publication_Services.ipynb
+++ b/GlobusWorldTour/Data_Publication_Services.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "## Prerequisites\n",
     "\n",
-    "To complete this tutorial you will need to make sure you are in the [Tutorial Users Group](https://www.globus.org/app/groups/50b6a29c-63ac-11e4-8062-22000ab68755)."
+    "To complete this tutorial you will need to make sure you are in the [Tutorial Users Group](https://app.globus.org/groups/50b6a29c-63ac-11e4-8062-22000ab68755)."
    ]
   },
   {
@@ -50,6 +50,9 @@
     "\n",
     "# ID of namespace where we create identifiers\n",
     "identifiers_namespace = \"HHxPIZaVDh9u\"\n",
+    "\n",
+    "# ID of this tutorial notebook as a Globus App\n",
+    "CLIENT_ID = 'd61ed2e0-b4f9-4fe9-9433-41e2528a807d'\n",
     "\n",
     "# python2/3 safe simple input reading\n",
     "get_input = getattr(__builtins__, 'raw_input', input)"
@@ -160,7 +163,7 @@
     "r = transfer.operation_mkdir(publication_endpoint, path=share_path)\n",
     "\n",
     "print(\"Publication path: %s\" % share_path)\n",
-    "print(\"https://www.globus.org/app/transfer?origin_id=%s&origin_path=%s\" % (publication_endpoint, share_path))"
+    "print(\"https://app.globus.org/file-manager?origin_id=%s&origin_path=%s\" % (publication_endpoint, share_path))"
    ]
   },
   {


### PR DESCRIPTION
* Updated links from old Globus Webapp to the newer one
* Fixed missing CLIENT_ID (used the old one originally present in this tutorial)

Note: @rpwagner I'm not sure we want to include the Identifiers Client in this presentation anymore. It works, and is currently setup to use test Minids. If we removed the Identifiers portion, this notebook would continue to be a full tutorial for how to index datasets into Globus Search. 