### PR TITLE
Updated Globus webapp links to point to app.globus.org

### DIFF
--- a/GlobusWorldTour/JupyterHub_Integration.ipynb
+++ b/GlobusWorldTour/JupyterHub_Integration.ipynb
@@ -29,7 +29,7 @@
     "* Start your server\n",
     "* Launch the notebook\n",
     "\n",
-    "Note 2: You need to join the  [Tutorial Users Group](https://www.globus.org/app/groups/50b6a29c-63ac-11e4-8062-22000ab68755) in order to access the shared endpoint at the end of the tutorial.</em>"
+    "Note 2: You need to join the  [Tutorial Users Group](https://app.globus.org/groups/50b6a29c-63ac-11e4-8062-22000ab68755) in order to access the shared endpoint at the end of the tutorial.</em>"
    ]
   },
   {
@@ -384,7 +384,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also look at the folders and permissions on the __[shared endpoint](https://www.globus.org/app/transfer?origin_id=e56c36e4-1063-11e6-a747-22000bf2d559&origin_path=%2Ftest%2Fjhtutorial%2F)__."
+    "We can also look at the folders and permissions on the __[shared endpoint](https://app.globus.org/file-manager?origin_id=e56c36e4-1063-11e6-a747-22000bf2d559&origin_path=%2Ftest%2Fjhtutorial%2F)__."
    ]
   }
  ],

--- a/GlobusWorldTour/Platform_Introduction_JupyterHub_Auth.ipynb
+++ b/GlobusWorldTour/Platform_Introduction_JupyterHub_Auth.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "\n",
     "# Requirements\n",
-    "- Membership in the [Tutorial Users Group](https://www.globus.org/app/groups/50b6a29c-63ac-11e4-8062-22000ab68755) for sharing.\n",
+    "- Membership in the [Tutorial Users Group](https://app.globus.org/groups/50b6a29c-63ac-11e4-8062-22000ab68755) for sharing.\n",
     "- Installed Globus Python SDK"
    ]
   },

--- a/GlobusWorldTour/Platform_Introduction_Native_App_Auth.ipynb
+++ b/GlobusWorldTour/Platform_Introduction_Native_App_Auth.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "\n",
     "# Requirements\n",
-    "- Membership in the [Tutorial Users Group](https://www.globus.org/app/groups/50b6a29c-63ac-11e4-8062-22000ab68755) for sharing.\n",
+    "- Membership in the [Tutorial Users Group](https://app.globus.org/groups/50b6a29c-63ac-11e4-8062-22000ab68755) for sharing.\n",
     "- Installed Globus Python SDK"
    ]
   },

--- a/SDK.ipynb
+++ b/SDK.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "\n",
     "# Requirements\n",
-    "- Membership in the [Tutorial Users Group](https://www.globus.org/app/groups/50b6a29c-63ac-11e4-8062-22000ab68755) for sharing.\n",
+    "- Membership in the [Tutorial Users Group](https://app.globus.org/groups/50b6a29c-63ac-11e4-8062-22000ab68755) for sharing.\n",
     "- Installed Globus Python SDK"
    ]
   },

--- a/SDK_exercises.ipynb
+++ b/SDK_exercises.ipynb
@@ -98,7 +98,7 @@
    "outputs": [],
    "source": [
     "# copy id from SDK notebook output,\n",
-    "# or find on Web app starting at https://www.globus.org/app/endpoints?scope=shared-by-me\n",
+    "# or find on Web app starting at https://app.globus.org/endpoints?scope=shared-by-me\n",
     "shared_endpoint_id = \"SETME\"\n",
     "ep_update = {\n",
     "    \"DATA_TYPE\": \"endpoint\",\n",

--- a/jupyterCon2018/JHTutorial.ipynb
+++ b/jupyterCon2018/JHTutorial.ipynb
@@ -30,7 +30,7 @@
     "* Start your server\n",
     "* Launch the notebook\n",
     "\n",
-    "Note 2: You need to join the tutorial group at https://www.globus.org/app/groups/50b6a29c-63ac-11e4-8062-22000ab68755/about to be able to access the shared endpoint at the end.</em>"
+    "Note 2: You need to join the tutorial group at https://app.globus.org/groups/50b6a29c-63ac-11e4-8062-22000ab68755/about to be able to access the shared endpoint at the end.</em>"
    ]
   },
   {
@@ -571,7 +571,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also look at the folders and permissions on the __[shared endpoint](https://www.globus.org/app/transfer?origin_id=e56c36e4-1063-11e6-a747-22000bf2d559&origin_path=%2Ftest%2Fjhtutorial%2F)__."
+    "We can also look at the folders and permissions on the __[shared endpoint](https://app.globus.org/file-manager?origin_id=e56c36e4-1063-11e6-a747-22000bf2d559&origin_path=%2Ftest%2Fjhtutorial%2F)__."
    ]
   }
  ],


### PR DESCRIPTION
I found a couple more old links in a notebook I needed, so I went ahead and `grep`ed all notebooks and updated them so nobody else is surprised by this during a demo. 