### PR TITLE
Added small cell to showcase records on petreldata.net

### DIFF
--- a/Data_Publication_Flow.ipynb
+++ b/Data_Publication_Flow.ipynb
@@ -273,7 +273,10 @@
     "    'title': 'My Globus Tutorial Dataset',\n",
     "    'contributors': ['John Smith', 'FrobozzCo', 'Zaphod Beeblebrox'],\n",
     "    'date': '2019-01-01',\n",
-    "    'keywords': ['FCD#3', 'Blanket', 'Panic', ]\n",
+    "    'keywords': ['FCD#3', 'Blanket', 'Panic', ],\n",
+    "    'files': [{\n",
+    "        'url': \"https://%s%s\" % (http_hostname, share_path)\n",
+    "    }]\n",
     "}"
    ]
   },
@@ -401,6 +404,30 @@
     "print(\"Documents indexed: %s\" % result['num_documents_ingested'])\n",
     "print(\"Subject: %s\" % subject)\n",
     "print(metadata)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Viewing Search Records\n",
+    "\n",
+    "Globus Search records can also be viewed at https://petreldata.net. Portals are a good way to visually present a large number of search results for users. \n",
+    "\n",
+    "The portal shown uses the same Globus SDK calls for generating queries that you will use below. Note the facets on the left, and the filter query params in the address bar. Each of these boil down into simple parameters passed into the Globus SDK."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from urllib.parse import quote_plus\n",
+    "search_index = 'globus-tutorial'\n",
+    "subject_enc = quote_plus(quote_plus(subject))\n",
+    "portal_url = f'https://petreldata.net/{search_index}/detail/{subject_enc}/'\n",
+    "print(f'Subject on Petreldata.net: {portal_url}')"
    ]
   },
   {


### PR DESCRIPTION
@vas Fixes for the Data Publication notebook

* Added 'files' block with a url so petreldata.net can display the file
* Added a small block to generate a URL for the portal

Other out-of-band fixes for this notebook:

* The ISI Identifier Service has been fixed, minting Minids should now work
* Fixed Jupyter servers not spawning reliably (Autoscaling wasn't turned on, doh!)


