### PR TITLE
Added external auth to automate notebook

### DIFF
--- a/Automation_Using_Globus_Flows.ipynb
+++ b/Automation_Using_Globus_Flows.ipynb
@@ -31,12 +31,12 @@
     "import uuid\n",
     "import pickle\n",
     "import base64\n",
+    "import pprint\n",
     "\n",
     "import globus_sdk\n",
-    "from globus_automate_client import create_flows_client\n",
+    "from globus_automate_client import FlowsClient\n",
     "\n",
-    "CLIENT_ID = 'e369806e-2351-414e-8ce9-ff49370defd3'\n",
-    "flows_client = create_flows_client(CLIENT_ID)\n",
+    "client_id = 'f794186b-f330-4595-b6c6-9c9d3e903e47'\n",
     "\n",
     "# Feel free to replace the endpoint UUIDs below with those of your own endpoints\n",
     "tutorial_endpoint = \"ddb59aef-6d04-11e5-ba46-22000b92c6ec\"  # endpoint \"Globus Tutorial Endpoint 1\"\n",
@@ -69,6 +69,39 @@
    "source": [
     "# Get Globus Auth token data from the JupyterHub environment\n",
     "tokens = pickle.loads(base64.b64decode(os.getenv('GLOBUS_DATA')))['tokens']\n",
+    "\n",
+    "# Create a variable for storing flow scope tokens. Each newly deployed scope needs to be authorized separately,\n",
+    "# and will have its own set of tokens. Save each of these tokens by scope.\n",
+    "saved_flow_scopes = {}\n",
+    "\n",
+    "# Add a callback to the flows client for fetching scopes. It will draw scopes from the `saved_flow_scopes` variable\n",
+    "# above.\n",
+    "def get_flow_authorizer(flow_url, flow_scope, client_id):\n",
+    "    return globus_sdk.AccessTokenAuthorizer(access_token=saved_flow_scopes[flow_scope]['access_token'])\n",
+    "\n",
+    "# Setup the flows client, using tokens from our Jupyterhub login to access the flows service, and\n",
+    "# setting the `get_flow_authorizer` callback for any new flows we authorize.\n",
+    "flows_authorizer = globus_sdk.AccessTokenAuthorizer(access_token=tokens['flows.globus.org']['access_token'])\n",
+    "flows_client = FlowsClient.new_client(\n",
+    "    client_id, get_flow_authorizer, flows_authorizer\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fetch User Identity for ACL Permissions\n",
+    "\n",
+    "After transferring files, the second part of the flow will add an ACL for a user. Below will fetch your user id so it can be granted read access."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "\n",
     "# Create an Auth client so we can look up identities\n",
     "auth_authorizer = globus_sdk.AccessTokenAuthorizer(access_token=tokens['auth.globus.org']['access_token'])\n",
@@ -164,9 +197,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create a Globus Flows client\n",
-    "flows_client = create_flows_client(CLIENT_ID)\n",
-    "\n",
     "# Deploy the flow\n",
     "flow_title = f\"Tutorial-Flow-{str(uuid.uuid4())}\"   # generate a unique title\n",
     "# flow = flows_client.update_flow(flow_id, flow_definition)\n",
@@ -218,6 +248,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Authorize the newly deployed flow\n",
+    "\n",
+    "The new flow has been deployed, but it still needs to be authorized."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If the flow scope is already saved, we don't need a new one.\n",
+    "if flow_scope not in saved_flow_scopes:\n",
+    "    # Do a native auth flow to login with the newly deployed flow scope\n",
+    "    native_auth_client = globus_sdk.NativeAppAuthClient(client_id)\n",
+    "    native_auth_client.oauth2_start_flow(requested_scopes=flow_scope)\n",
+    "    print(f\"Login Here:\\n\\n{native_auth_client.oauth2_get_authorize_url()}\")\n",
+    "    auth_code = input('Auth Code> ')\n",
+    "    token_response = native_auth_client.oauth2_exchange_code_for_tokens(auth_code)\n",
+    "    \n",
+    "    # Save the new token in a place where the flows client can retrieve it.\n",
+    "    saved_flow_scopes[flow_scope] = token_response.by_scopes[flow_scope]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Run the flow\n",
     "\n",
     "We're finally ready to run the flow. Note that you will be required to consent again."
@@ -229,8 +287,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pprint import pprint\n",
-    "\n",
     "flow_action = flows_client.run_flow(flow_id, flow_scope, flow_input)\n",
     "flow_action_id = flow_action['action_id']\n",
     "flow_status = flow_action['status']\n",
@@ -240,7 +296,7 @@
     "    flow_action = flows_client.flow_action_status(flow_id, flow_scope, flow_action_id)\n",
     "    flow_status = flow_action['status']\n",
     "    print(f'Flow status: {flow_status}')\n",
-    "pprint(flow_action.data)"
+    "pprint.pprint(flow_action.data)"
    ]
   },
   {
@@ -266,13 +322,6 @@
     "response = tc.delete_endpoint_acl_rule(petrel_endpoint, access_rule_id)\n",
     "print (response)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
These changes re-use tokens from the Jupyterhub login, and perform native auth flows for any newly deployed flows and save the tokens in a variable called `saved_flow_scopes`. 