### PR TITLE
Pin Globus SDK < v3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jupyter
 minid>=minid2.0.0b4
-globus-sdk>=1.7.0
+globus-sdk<3.0.0>=1.7.0
 globus-automate-client>=0.11.4


### PR DESCRIPTION
I didn't spot any incompatibilities inside any of the notebooks here. The only potential one in Globus SDK v3 is importing exceptions directly from `globus.exc`, and none of the notebooks here appear to do that.

The only thing that breaks in version 3 of the Globus SDK is the Minid client, which will require a new beta release before the Search notebook can be used with v3. Pinning the requirements to v2 will prevent folks running these notebooks from running into that issue. 