### PR TITLE
fix: Update old GCS HTTPS link for Jupyterhub integration

### DIFF
--- a/JupyterHub_Integration.ipynb
+++ b/JupyterHub_Integration.ipynb
@@ -198,7 +198,7 @@
    "outputs": [],
    "source": [
     "# GET the CSV from the publicly accessible HTTPS GCS endpoint\n",
-    "url = 'https://a4969.36fe.dn.glob.us/portal/catalog/dataset_las/1952.csv'\n",
+    "url = 'https://g-fe1c1.fd635.8443.data.globus.org/portal/catalog/dataset_las/1952.csv'\n",
     "headers = {'X-Requested-With': 'XMLHttpRequest'}\n",
     "resp = requests.get(url, headers=headers).text\n",
     "csv_rows = csv.DictReader(StringIO(resp))\n",

--- a/JupyterHub_Integration.ipynb
+++ b/JupyterHub_Integration.ipynb
@@ -199,7 +199,8 @@
    "source": [
     "# GET the CSV from the publicly accessible HTTPS GCS endpoint\n",
     "url = 'https://g-fe1c1.fd635.8443.data.globus.org/portal/catalog/dataset_las/1952.csv'\n",
-    "headers = {'X-Requested-With': 'XMLHttpRequest'}\n",
+    "https_token = tokens['tokens']['a6f165fa-aee2-4fe5-95f3-97429c28bf82']['access_token']\n",
+    "headers = {'X-Requested-With': 'XMLHttpRequest', 'Authorization': f'Bearer {https_token}'}\n",
     "resp = requests.get(url, headers=headers).text\n",
     "csv_rows = csv.DictReader(StringIO(resp))\n",
     "\n",


### PR DESCRIPTION
There are two parts to this fix. The first is simply updating the hostname below to match the current hostname. The second part of the fix was enabling public access to the data on the GCS collection, which previously allowed all authenticated users access but disallowed public. Since the tutorial doesn't yet demonstrate tokens, the call previously failed with an auth error. With the new rule, it functions as expected.