### PR TITLE
fix: Update Gladier notebook to use v0.9.0

### DIFF
--- a/Gladier_Flows_Tutorial.ipynb
+++ b/Gladier_Flows_Tutorial.ipynb
@@ -8,10 +8,10 @@
     "### Gladier: The Globus Architecture for Data-Intensive Experimental Research.\n",
     "\n",
     "Gladier is a programmable data capture, storage, and analysis architecture for experimental facilities. The architecture leverages a data and computing substrate based on agents deployed across computer and storage systems at APS, ALCF, and elsewhere, all managed by cloud-hosted Globus services. In particular, we leverage [Globus Connect](https://www.globus.org/globus-connect)\n",
-    "and [funcX](https://funcx.org) agents to facilitate secure, reliable remote data and computation and employ the [Globus Flows](https://www.globus.org/platform/services/flows) platform to orchestrate distributed data management tasks into reliable pipelines.\n",
+    "and [Globus Compute](https://globus-compute.readthedocs.io/en/latest/) agents to facilitate secure, reliable remote data and computation and employ the [Globus Flows](https://www.globus.org/platform/services/flows) platform to orchestrate distributed data management tasks into reliable pipelines.\n",
     "\n",
     "## Gladier Toolkit\n",
-    "The Gladier toolkit provides tools and capabilities to simplify and accelerate the development of these automations. The toolkit manages the dynamic creation of flows, automatically registers funcX functions, and assists in validating inputs. \n",
+    "The Gladier toolkit provides tools and capabilities to simplify and accelerate the development of these automations. The toolkit manages the dynamic creation of flows, automatically registers Globus Compute functions, and assists in validating inputs. \n",
     "\n",
     "Here we demonstrate how the Gladier toolkit can be used to let anyone create a simple, yet powerful client to automate data management tasks.\n",
     "\n",
@@ -101,7 +101,7 @@
    "source": [
     "## Gladier Tools\n",
     "\n",
-    "Gladier Tools are the glue that holds together Globus Flows and funcX functions. Tools bundle everything the funcX function needs to run, so the Glaider Client can register the function, check the requirements, and run it inside the flow.\n",
+    "Gladier Tools are the glue that holds together Globus Flows and Compute Functions. Tools bundle everything the Compute Function needs to run, so the Glaider Client can register the function, check the requirements, and run it inside the flow.\n",
     "\n",
     "We need three Flow States below to run our full experiment:\n",
     "\n",
@@ -109,7 +109,7 @@
     "2. GatherMetadata -- A function to gather results of the experiment\n",
     "3. PublishMetadata -- A flow state to ingest the metadata into Globus Search\n",
     "\n",
-    "The first two Gladier Tools are FuncX Functions, and use the `@generate_flow_definition` decorator to create the flow state for each function. The final publication state does not use the decorator, and instead uses a static flow definition. Gladier will chain each of these together into one single flow, run one after the other.  "
+    "The first two Gladier Tools are Compute Functions, and use the `@generate_flow_definition` decorator to create the flow state for each function. The final publication state does not use the decorator, and instead uses a static flow definition. Gladier will chain each of these together into one single flow, run one after the other.  "
    ]
   },
   {
@@ -130,7 +130,7 @@
     "\n",
     "@generate_flow_definition\n",
     "class RunExperiment(GladierBaseTool):\n",
-    "    funcx_functions = [run_experiment]"
+    "    compute_functions = [run_experiment]"
    ]
   },
   {
@@ -179,7 +179,7 @@
     "\n",
     "@generate_flow_definition\n",
     "class GatherMetadata(GladierBaseTool):\n",
-    "    funcx_functions = [gather_metadata]"
+    "    compute_functions = [gather_metadata]"
    ]
   },
   {
@@ -205,7 +205,7 @@
     "            }\n",
     "        },\n",
     "    }\n",
-    "    funcx_functions = []\n"
+    "    compute_functions = []\n"
    ]
   },
   {
@@ -214,7 +214,7 @@
    "source": [
     "## Gladier Clients\n",
     "\n",
-    "Gladier Clients manage a collection of Glaider Tools and a Globus Flow to link them together into a pipeline. Clients handle both registering funcX functions for each tool and registering the flow to orchestrate each tool's execution. The checksum of the flows and funcX functions are checked prior to each invocation to ensure they are always up-to-date. Further, the client checks the necessary inputs to each tool are present before the flow is invoked.\n",
+    "Gladier Clients manage a collection of Glaider Tools and a Globus Flow to link them together into a pipeline. Clients handle both registering Compute Functions for each tool and registering the flow to orchestrate each tool's execution. The checksum of the flows and Compute Functions are checked prior to each invocation to ensure they are always up-to-date. Further, the client checks the necessary inputs to each tool are present before the flow is invoked.\n",
     "\n",
     "Once a tool has been created it can be imported and used by a client. The client can then dynamically create a flow using the list of tools.\n",
     "\n",
@@ -251,11 +251,11 @@
    "source": [
     "## Flow Input\n",
     "\n",
-    "As you can see from the flow definition the input arguments for the tool have been dynamically defined. In this case, the `FileSize` tool requires a `funcx_endpoint_compute`, `file_size_funcx_id` and the entire `input` document is passed as the function payload. These values can be overridden in the flow or defined in the Tool definition.\n",
+    "As you can see from the flow definition the input arguments for the tool have been dynamically defined. In this case, the `FileSize` tool requires a `compute_endpoint`, `file_size_function_id` and the entire `input` document is passed as the function payload. These values can be overridden in the flow or defined in the Tool definition.\n",
     "\n",
-    "It is important to note that the funcX function id, `file_size_funcx_id` is automatically populated by the Client at runtime. This allows the client to check whether the function definition has changed and re-register the function with funcX if necessary. As such, you do not need to specify the function id as input to the flow.\n",
+    "It is important to note that the compute function id, `file_size_function_id` is automatically populated by the Client at runtime. This allows the client to check whether the function definition has changed and re-register the function with Globus Compute if necessary. As such, you do not need to specify the function id as input to the flow.\n",
     "\n",
-    "Here we define the input to include a pathname for the tool to act on and a public funcX endpoint to perform the execution."
+    "Here we define the input to include a pathname for the tool to act on and a public Globus Compute Endpoint to perform the execution."
    ]
   },
   {
@@ -271,7 +271,7 @@
     "    'input': {\n",
     "        'experiment': str(experiment),\n",
     "        'subject': str(subject),\n",
-    "        'funcx_endpoint_compute': '4b116d3c-1703-4f8f-9f6f-39921e5864df',\n",
+    "        'compute_endpoint': '4b116d3c-1703-4f8f-9f6f-39921e5864df',\n",
     "        'search_index': search_index,\n",
     "    }\n",
     "}"
@@ -308,7 +308,7 @@
     "\n",
     "Now input has been created we can use the client to start and monitor the flow.\n",
     "\n",
-    "This will prompt you to authenticate and grant permission to the flow to perform a funcX invocation on your behalf. You may need to login twice, once for the static scopes required by Gladier. Second, for the new flow you have just deployed."
+    "This will prompt you to authenticate and grant permission to the flow to run a Globus Compute function on your behalf. You may need to login twice, once for the static scopes required by Gladier. Second, for the new flow you have just deployed."
    ]
   },
   {
@@ -344,9 +344,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This mainly consists of renaming FuncX to Globus Compute. The code itself is backwards compatible with the exception that `funcx_endpoint_compute` has been replaced with `compute_endpoint` and needs to be specified on input, but the changes here also rename `funcx_functions` to `compute_functions`.