### PR TITLE
refactor: Change all notebooks to use new GCS v5 Tutorial Collections

### DIFF
--- a/Automation_Using_Flows_With_Search.ipynb
+++ b/Automation_Using_Flows_With_Search.ipynb
@@ -43,12 +43,13 @@
     "import base64\n",
     "\n",
     "import globus_sdk\n",
+    "import globus_sdk.scopes\n",
     "\n",
     "# ID of this tutorial notebook as registered with Globus Auth\n",
     "CLIENT_ID = 'f794186b-f330-4595-b6c6-9c9d3e903e47'\n",
     "\n",
     "# Feel free to replace the collection UUIDs below with those of your own collections\n",
-    "source_collection = \"ddb59aef-6d04-11e5-ba46-22000b92c6ec\"  # \"Globus Tutorial Endpoint 1\"\n",
+    "source_collection = \"6c54cade-bde5-45c1-bdea-f4bd71dba2cc\"  # \"Globus Tutorial Collection 1\"\n",
     "destination_collection = \"a6f165fa-aee2-4fe5-95f3-97429c28bf82\"  # \"Globus Tutorials on ALCF Eagle\"\n",
     "my_collaborators = \"50b6a29c-63ac-11e4-8062-22000ab68755\"  # \"Tutorial Users\" group"
    ]
@@ -76,6 +77,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Create transfer scope with data_access scope dependency from the source mapped collection.\n",
+    "transfer_scope = globus_sdk.scopes.TransferScopes.make_mutable(\"all\")\n",
+    "data_access_scope = globus_sdk.scopes.GCSCollectionScopeBuilder(source_collection).data_access\n",
+    "transfer_scope.add_dependency(data_access_scope)\n",
+    "\n",
     "# Get Globus Auth token data from the JupyterHub environment\n",
     "globus_data_raw = os.getenv(\"GLOBUS_DATA\")\n",
     "if globus_data_raw:\n",
@@ -86,7 +92,7 @@
     "        \"openid\",\n",
     "        \"profile\",\n",
     "        \"email\",\n",
-    "        globus_sdk.TransferClient.scopes.all,\n",
+    "        transfer_scope,\n",
     "        globus_sdk.SearchClient.scopes.all,\n",
     "        globus_sdk.FlowsClient.scopes.manage_flows,\n",
     "        globus_sdk.FlowsClient.scopes.run_manage,\n",
@@ -487,7 +493,8 @@
     "    input_schema=input_schema,\n",
     ")\n",
     "flow_id = flow['id']\n",
-    "flow_scope = flow['globus_auth_scope']\n",
+    "flow_scope = globus_sdk.SpecificFlowClient(flow_id).scopes.make_mutable(\"user\")\n",
+    "flow_scope.add_dependency(transfer_scope)\n",
     "\n",
     "\"\"\"\n",
     "# If you change the flow, you will need to update it.\n",
@@ -564,7 +571,7 @@
     "        # Transfer input\n",
     "        \"source\": {\n",
     "            \"id\": source_collection,\n",
-    "            \"path\": \"/share/godata\",\n",
+    "            \"path\": \"/home/share/godata/\",\n",
     "        },\n",
     "        \"destination\": {\n",
     "            \"id\": destination_collection,\n",
@@ -732,13 +739,6 @@
    "source": [
     "print(f\"View sharing permissions: \\nhttps://app.globus.org/file-manager/collections/{destination_collection}/sharing\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -757,7 +757,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/Automation_Using_Globus_Flows.ipynb
+++ b/Automation_Using_Globus_Flows.ipynb
@@ -33,12 +33,13 @@
     "import base64\n",
     "\n",
     "import globus_sdk\n",
+    "import globus_sdk.scopes\n",
     "\n",
     "# ID of this tutorial notebook as registered with Globus Auth\n",
     "CLIENT_ID = 'f794186b-f330-4595-b6c6-9c9d3e903e47'\n",
     "\n",
     "# Feel free to replace the collection UUIDs below with those of your own collections\n",
-    "source_collection = \"ddb59aef-6d04-11e5-ba46-22000b92c6ec\"  # \"Globus Tutorial Endpoint 1\"\n",
+    "source_collection = \"6c54cade-bde5-45c1-bdea-f4bd71dba2cc\"  # \"Globus Tutorial Collection 1\"\n",
     "destination_collection = \"a6f165fa-aee2-4fe5-95f3-97429c28bf82\"  # \"Globus Tutorials on ALCF Eagle\"\n",
     "my_collaborators = \"50b6a29c-63ac-11e4-8062-22000ab68755\"  # \"Tutorial Users\" group"
    ]
@@ -68,6 +69,11 @@
    },
    "outputs": [],
    "source": [
+    "# Create transfer scope with data_access scope dependency from the source mapped collection.\n",
+    "transfer_scope = globus_sdk.scopes.TransferScopes.make_mutable(\"all\")\n",
+    "data_access_scope = globus_sdk.scopes.GCSCollectionScopeBuilder(source_collection).data_access\n",
+    "transfer_scope.add_dependency(data_access_scope)\n",
+    "\n",
     "# Try to get Globus Auth token data from the JupyterHub environment\n",
     "globus_data_raw = os.getenv(\"GLOBUS_DATA\")\n",
     "if globus_data_raw:\n",
@@ -78,7 +84,7 @@
     "        \"openid\",\n",
     "        \"profile\",\n",
     "        \"email\",\n",
-    "        globus_sdk.TransferClient.scopes.all,\n",
+    "        transfer_scope,\n",
     "        globus_sdk.FlowsClient.scopes.manage_flows,\n",
     "        globus_sdk.FlowsClient.scopes.run_manage,\n",
     "    ]\n",
@@ -340,7 +346,9 @@
     "    input_schema=input_schema,\n",
     ")\n",
     "flow_id = flow['id']\n",
-    "flow_scope = flow['globus_auth_scope']\n",
+    "flow_scope = globus_sdk.SpecificFlowClient(flow_id).scopes.make_mutable(\"user\")\n",
+    "flow_scope.add_dependency(transfer_scope)\n",
+    "\n",
     "\n",
     "\"\"\"\n",
     "# If you change the flow, you will need to update it.\n",
@@ -407,7 +415,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
    "outputs": [],
    "source": [
     "# Define flow inputs\n",
@@ -417,7 +429,7 @@
     "        # Transfer input\n",
     "        \"source\": {\n",
     "            \"id\": source_collection,\n",
-    "            \"path\": \"/share/godata\"\n",
+    "            \"path\": \"/home/share/godata/\"\n",
     "        },\n",
     "        \"destination\": {\n",
     "            \"id\": destination_collection,\n",
@@ -582,9 +594,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/Metadata_Search_and_Discovery.ipynb
+++ b/Metadata_Search_and_Discovery.ipynb
@@ -169,10 +169,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# define the source endpoint and directory containing data to be published\n",
-    "# (Globus Tutorial Endpoint 1):/share/godata/\n",
-    "source_collection = 'ddb59aef-6d04-11e5-ba46-22000b92c6ec'\n",
-    "source_path = '/share/godata/file1.txt'\n",
+    "# define the source collection and directory containing data to be published\n",
+    "# (Globus Tutorial Collection 1):/home/share/godata/\n",
+    "source_collection = '6c54cade-bde5-45c1-bdea-f4bd71dba2cc'\n",
+    "source_path = '/home/share/godata/file1.txt'\n",
     "destination_filename = share_path + os.path.basename(source_path)\n",
     "\n",
     "# TransferData is a helper function for building good Transfer Task documents for the Globus Transfer Service\n",
@@ -640,9 +640,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/Platform_Introduction_JupyterHub_Auth.ipynb
+++ b/Platform_Introduction_JupyterHub_Auth.ipynb
@@ -25,8 +25,8 @@
     "import json  # just so we can pretty-print response data\n",
     "\n",
     "# Feel free to replace the endpoint UUIDs below with those of your own endpoints\n",
-    "tutorial_endpoint_1 = \"ddb59aef-6d04-11e5-ba46-22000b92c6ec\"  # endpoint \"Globus Tutorial Endpoint 1\"\n",
-    "tutorial_endpoint_2 = \"ddb59af0-6d04-11e5-ba46-22000b92c6ec\"  # endpoint \"Globus Tutorial Endpoint 2\"\n",
+    "tutorial_endpoint_1 = \"6c54cade-bde5-45c1-bdea-f4bd71dba2cc\"  # endpoint \"Globus Tutorial Endpoint 1\"\n",
+    "tutorial_endpoint_2 = \"31ce9ba0-176d-45a5-add3-f37d233ba47d\"  # endpoint \"Globus Tutorial Endpoint 2\"\n",
     "tutorial_users_group = \"50b6a29c-63ac-11e4-8062-22000ab68755\"  # group \"Tutorial Users\"\n",
     "\n",
     "# These are to get the tokens\n",
@@ -317,7 +317,7 @@
    "source": [
     "# help(tc.operation_ls)\n",
     "endpoint_id = tutorial_endpoint_1\n",
-    "endpoint_path = \"/share/godata/\"\n",
+    "endpoint_path = \"/home/share/godata/\"\n",
     "response = tc.operation_ls(endpoint_id, path=endpoint_path)\n",
     "print(f\"==== 'ls' for {endpoint_path} on endpoint {endpoint_id} ====\")\n",
     "for item in response:\n",
@@ -399,7 +399,7 @@
    "source": [
     "# help(tc.submit_transfer)\n",
     "source_endpoint_id = tutorial_endpoint_1\n",
-    "source_path = \"/share/godata/\"\n",
+    "source_path = \"/home/share/godata/\"\n",
     "\n",
     "dest_endpoint_id = tutorial_endpoint_2\n",
     "dest_path = \"/~/\"\n",
@@ -660,7 +660,7 @@
    "source": [
     "bookmark_name = \"My Tutorial Bookmark\"\n",
     "endpoint_id = tutorial_endpoint_1\n",
-    "endpoint_path = \"/share/godata/\"\n",
+    "endpoint_path = \"/home/share/godata/\"\n",
     "response = tc.create_bookmark({\"endpoint_id\": endpoint_id, \"path\": endpoint_path,\"name\": bookmark_name})\n",
     "bookmark_id = response['id']\n",
     "print(response)"
@@ -1053,9 +1053,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/Platform_Introduction_Native_App_Auth.ipynb
+++ b/Platform_Introduction_Native_App_Auth.ipynb
@@ -24,8 +24,8 @@
     "import json  # just so we can pretty-print response data\n",
     "\n",
     "# Feel free to replace the endpoint UUIDs below with those of your own endpoints\n",
-    "tutorial_endpoint_1 = \"ddb59aef-6d04-11e5-ba46-22000b92c6ec\"  # endpoint \"Globus Tutorial Endpoint 1\"\n",
-    "tutorial_endpoint_2 = \"ddb59af0-6d04-11e5-ba46-22000b92c6ec\"  # endpoint \"Globus Tutorial Endpoint 2\"\n",
+    "tutorial_endpoint_1 = \"6c54cade-bde5-45c1-bdea-f4bd71dba2cc\"  # endpoint \"Globus Tutorial Endpoint 1\"\n",
+    "tutorial_endpoint_2 = \"31ce9ba0-176d-45a5-add3-f37d233ba47d\"  # endpoint \"Globus Tutorial Endpoint 2\"\n",
     "tutorial_users_group = \"50b6a29c-63ac-11e4-8062-22000ab68755\"  # group \"Tutorial Users\""
    ]
   },
@@ -61,8 +61,20 @@
     "# First, create a client object that tracks state as we do this flow\n",
     "native_auth_client = globus_sdk.NativeAppAuthClient(CLIENT_ID)\n",
     "\n",
+    "# Get GCS Data Access scopes for both mapped collections. These are needed to access any data on\n",
+    "# a mapped collection\n",
+    "tc1_data_access = globus_sdk.scopes.GCSCollectionScopeBuilder(tutorial_endpoint_1).data_access\n",
+    "tc2_data_access = globus_sdk.scopes.GCSCollectionScopeBuilder(tutorial_endpoint_2).data_access\n",
+    "\n",
+    "# Add scopes as dependencies for the transfer scope, allowing transfer operations to access data\n",
+    "# on both tutorial mapped collections.\n",
+    "transfer_scope = globus_sdk.scopes.TransferScopes.make_mutable(\"all\")\n",
+    "transfer_scope.add_dependency(tc1_data_access)\n",
+    "transfer_scope.add_dependency(tc2_data_access)\n",
+    "\n",
+    "\n",
     "# Explicitly start the flow (some clients may support multiple flows)\n",
-    "native_auth_client.oauth2_start_flow()\n",
+    "native_auth_client.oauth2_start_flow(requested_scopes=[transfer_scope])\n",
     "print(f\"Login Here:\\n\\n{native_auth_client.oauth2_get_authorize_url()}\")\n",
     "print(\"\\nIMPORTANT NOTE: the link above can only be used once!\")\n",
     "print(\"If login or a later step in the flow fails, you must execute this cell again to generate a new link.\")"
@@ -334,7 +346,7 @@
    "source": [
     "# help(tc.operation_ls)\n",
     "endpoint_id = tutorial_endpoint_1\n",
-    "endpoint_path = \"/share/godata/\"\n",
+    "endpoint_path = \"/home/share/godata/\"\n",
     "response = tc.operation_ls(endpoint_id, path=endpoint_path)\n",
     "print(f\"==== 'ls' for {endpoint_path} on endpoint {endpoint_id} ====\")\n",
     "for item in response:\n",
@@ -416,7 +428,7 @@
    "source": [
     "# help(tc.submit_transfer)\n",
     "source_endpoint_id = tutorial_endpoint_1\n",
-    "source_path = \"/share/godata/\"\n",
+    "source_path = \"/home/share/godata/\"\n",
     "\n",
     "dest_endpoint_id = tutorial_endpoint_2\n",
     "dest_path = \"/~/\"\n",
@@ -677,7 +689,7 @@
    "source": [
     "bookmark_name = \"My Tutorial Bookmark\"\n",
     "endpoint_id = tutorial_endpoint_1\n",
-    "endpoint_path = \"/share/godata/\"\n",
+    "endpoint_path = \"/home/share/godata/\"\n",
     "response = tc.create_bookmark({\"endpoint_id\": endpoint_id, \"path\": endpoint_path,\"name\": bookmark_name})\n",
     "bookmark_id = response['id']\n",
     "print(response)"
@@ -1072,9 +1084,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/Transfer_API_Exercises.ipynb
+++ b/Transfer_API_Exercises.ipynb
@@ -35,13 +35,31 @@
    "source": [
     "import globus_sdk\n",
     "\n",
-    "tutorial_endpoint_1 = \"ddb59aef-6d04-11e5-ba46-22000b92c6ec\"      # endpoint \"Globus Tutorial Endpoint 1\"\n",
-    "tutorial_endpoint_2 = \"ddb59af0-6d04-11e5-ba46-22000b92c6ec\"      # endpoint \"Globus Tutorial Endpoint 2\"\n",
+    "CLIENT_ID = \"3b1925c0-a87b-452b-a492-2c9921d3bd14\"\n",
+    "native_auth_client = globus_sdk.NativeAppAuthClient(CLIENT_ID)\n",
     "\n",
+    "tutorial_endpoint_1 = \"6c54cade-bde5-45c1-bdea-f4bd71dba2cc\"  # endpoint \"Globus Tutorial Endpoint 1\"\n",
+    "tutorial_endpoint_2 = \"31ce9ba0-176d-45a5-add3-f37d233ba47d\"  # endpoint \"Globus Tutorial Endpoint 2\"\n",
+    "\n",
+    "# Get GCS Data Access scopes for both mapped collections. These are needed to access any data on\n",
+    "# a mapped collection\n",
+    "tc1_data_access = globus_sdk.scopes.GCSCollectionScopeBuilder(tutorial_endpoint_1).data_access\n",
+    "tc2_data_access = globus_sdk.scopes.GCSCollectionScopeBuilder(tutorial_endpoint_2).data_access\n",
+    "\n",
+    "# Add scopes as dependencies for the transfer scope, allowing transfer operations to access data\n",
+    "# on both tutorial mapped collections.\n",
+    "transfer_scope = globus_sdk.scopes.TransferScopes.make_mutable(\"all\")\n",
+    "transfer_scope.add_dependency(tc1_data_access)\n",
+    "transfer_scope.add_dependency(tc2_data_access)\n",
     "\n",
     "# As in the Platform_Introduction_Native_App_Auth notebook, do the Native App Grant Flow\n",
-    "CLIENT_ID = \"3b1925c0-a87b-452b-a492-2c9921d3bd14\"\n",
-    "SCOPES = \"openid profile email urn:globus:auth:scope:transfer.api.globus.org:all urn:globus:auth:scope:auth.globus.org:view_identities\"\n",
+    "SCOPES = [\n",
+    "    \"openid\",\n",
+    "    \"profile\",\n",
+    "    \"email\",\n",
+    "    \"urn:globus:auth:scope:auth.globus.org:view_identities\",\n",
+    "    transfer_scope,\n",
+    "]\n",
     "native_auth_client = globus_sdk.NativeAppAuthClient(CLIENT_ID)\n",
     "native_auth_client.oauth2_start_flow(requested_scopes=SCOPES)\n",
     "print(f\"Login Here:\\n\\n{native_auth_client.oauth2_get_authorize_url()}\")"
@@ -78,7 +96,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "endpoint_name = \"XSEDE TACC Stampede2\"\n",
+    "endpoint_name = \"XSEDE TACC Stampede\"\n",
     "endpoints = tc.endpoint_search(endpoint_name, query_params={\"fields\": \"id,display_name\"})\n",
     "endpoint_id = None\n",
     "for ep in endpoints:\n",
@@ -267,7 +285,7 @@
     "tdata = globus_sdk.TransferData(tc, source_id, dest_id,\n",
     "                                delete_destination_extra=True,\n",
     "                                preserve_timestamp=True)\n",
-    "tdata.add_item(\"/share/godata/\", \"/~/notebook_godata/\", recursive=True)\n",
+    "tdata.add_item(\"/home/share/godata/\", \"/~/notebook_godata/\", recursive=True)\n",
     "\n",
     "submit_result = tc.submit_transfer(tdata)\n",
     "\n",
@@ -330,7 +348,7 @@
     "tc.endpoint_autoactivate(source_id)\n",
     "tc.endpoint_autoactivate(dest_id)\n",
     "\n",
-    "source_path = \"/share/godata/\"\n",
+    "source_path = \"/home/share/godata/\"\n",
     "dest_path = \"/~/notebook_txt_godata/\"\n",
     "\n",
     "tdata = globus_sdk.TransferData(tc, source_id, dest_id)\n",
@@ -366,8 +384,8 @@
     "tc.endpoint_autoactivate(dest_id)\n",
     "\n",
     "tdata = globus_sdk.TransferData(tc, source_id, dest_id)\n",
-    "tdata.add_item(\"/share/godata/\", \"/~/notebook_godata/\", recursive=True)\n",
-    "tdata.add_item(\"/share/godata/dne.txt\", \"/~/notebook_godata/dne.txt\")  # file dne.txt does not exist\n",
+    "tdata.add_item(\"/home/share/godata/\", \"/~/notebook_godata/\", recursive=True)\n",
+    "tdata.add_item(\"/home/share/godata/dne.txt\", \"/~/notebook_godata/dne.txt\")  # file dne.txt does not exist\n",
     "\n",
     "submit_result = tc.submit_transfer(tdata)\n",
     "\n",
@@ -385,7 +403,7 @@
     "\n",
     "while True:\n",
     "    # Check if task has completed\n",
-    "    status = tc.get_task(submit_result['task_id'], fields=\"status\")['status']\n",
+    "    status = tc.get_task(submit_result['task_id'])['status']\n",
     "    if status in (\"SUCCEEDED\", \"FAILED\"):\n",
     "        print(f\"Task completed with status {status}\")\n",
     "        break\n",
@@ -393,7 +411,7 @@
     "    # Search the most recent errors for anything that we want to trigger a cancel,\n",
     "    # stopping if we get to an error we already saw in a previous iteration of the\n",
     "    # wait loop (the event list is sorted newest first).\n",
-    "    for error in tc.task_event_list(submit_result['task_id'], filter=\"is_error:1\"):\n",
+    "    for error in tc.task_event_list(submit_result['task_id'], query_params=dict(filter_is_error=True)):\n",
     "        if error['code'] in cancel_on_errors:\n",
     "            print(\"Encountered bad error, canceling task\")\n",
     "            tc.cancel_task(submit_result['task_id'])\n",
@@ -417,11 +435,18 @@
     "    time.sleep(poll_interval)\n",
     "    wait_time += poll_interval"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -435,9 +460,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Not all notebooks use the tutorial collections, but many of them to. This covers all functional changes in order to switch to using the tutorial collections. This mostly covers scope changes and core functionality, things like renaming vars and removing autoactivation calls will be done in another PR