### PR TITLE
Update compute example

### DIFF
--- a/Compute_Introduction.ipynb
+++ b/Compute_Introduction.ipynb
@@ -21,18 +21,25 @@
     "\n",
     "    $ pip install globus-compute-sdk\n",
     "\n",
-    "The Globus Compute SDK exposes a `Client` and `Executor` for interacting with the Globus Compute service. In order to use Globus Compute, you must first authenticate using one of hundreds of supported identity provides (e.g., your institution, ORCID, or Google).  As part of the authentication process you must grant permission for Globus Compute to access your identity information (to retrieve your email address) and Globus Groups management access (to share endpoints)."
+    "The Globus Compute SDK exposes a `Client` and `Executor` for interacting with the Globus Compute service. In order to use Globus Compute, you must first authenticate using one of hundreds of supported identity provides (e.g., your institution, ORCID, or Google).  As part of the authentication process you must grant permission for Globus Compute to access your identity information (to retrieve your email address)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from globus_compute_sdk import Executor"
+    "import os\n",
+    "import json\n",
+    "import pickle\n",
+    "import base64\n",
+    "import globus_sdk\n",
+    "from globus_sdk.scopes import AuthScopes\n",
+    "\n",
+    "from globus_compute_sdk import Executor, Client\n",
+    "from globus_compute_sdk.sdk.login_manager import AuthorizerLoginManager\n",
+    "from globus_compute_sdk.sdk.login_manager.manager import ComputeScopeBuilder"
    ]
   },
   {
@@ -54,6 +61,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an Executor to submit tasks.\n",
+    "\n",
+    "This will attempt to use tokens from the Jupyter Hub enviornment. An authentication flow will be used to verify your identity if tokens are not available."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -61,7 +77,29 @@
    },
    "outputs": [],
    "source": [
-    "gce = Executor(endpoint_id = tutorial_endpoint)\n",
+    "# Try to get Globus Auth token data from the JupyterHub environment\n",
+    "globus_data_raw = os.getenv(\"GLOBUS_DATA\")\n",
+    "if globus_data_raw:\n",
+    "    tokens = pickle.loads(base64.b64decode(os.getenv('GLOBUS_DATA')))['tokens']\n",
+    "    \n",
+    "    ComputeScopes = ComputeScopeBuilder()\n",
+    "    \n",
+    "    # Create Authorizers from the Compute and Auth tokens\n",
+    "    compute_auth = globus_sdk.AccessTokenAuthorizer(tokens[ComputeScopes.resource_server]['access_token'])\n",
+    "    openid_auth = globus_sdk.AccessTokenAuthorizer(tokens['auth.globus.org']['access_token'])\n",
+    "    \n",
+    "    # Create a Compute Client from these authorizers\n",
+    "    compute_login_manager = AuthorizerLoginManager(\n",
+    "        authorizers={ComputeScopes.resource_server: compute_auth,\n",
+    "                     AuthScopes.resource_server: openid_auth}\n",
+    "    )\n",
+    "    compute_login_manager.ensure_logged_in()\n",
+    "    \n",
+    "    gc = Client(login_manager=compute_login_manager)\n",
+    "    gce = Executor(endpoint_id=tutorial_endpoint, funcx_client=gc)\n",
+    "else:\n",
+    "    # Create an Executor and initiate an auth flow if tokens are not available\n",
+    "    gce = Executor(endpoint_id=tutorial_endpoint)\n",
     "print(\"Executor : \", gce)"
    ]
   },

--- a/Compute_Introduction.ipynb
+++ b/Compute_Introduction.ipynb
@@ -37,7 +37,8 @@
     "import globus_sdk\n",
     "from globus_sdk.scopes import AuthScopes\n",
     "\n",
-    "from globus_compute_sdk import Executor, Client\n",
+    "from globus_compute_sdk import Client, Executor\n",
+    "from globus_compute_sdk.serialize import CombinedCode\n",
     "from globus_compute_sdk.sdk.login_manager import AuthorizerLoginManager\n",
     "from globus_compute_sdk.sdk.login_manager.manager import ComputeScopeBuilder"
    ]
@@ -94,12 +95,12 @@
     "                     AuthScopes.resource_server: openid_auth}\n",
     "    )\n",
     "    compute_login_manager.ensure_logged_in()\n",
-    "    \n",
-    "    gc = Client(login_manager=compute_login_manager)\n",
-    "    gce = Executor(endpoint_id=tutorial_endpoint, funcx_client=gc)\n",
+    "    gc = Client(login_manager=compute_login_manager, code_serialization_strategy=CombinedCode())\n",
+    "    gce = Executor(endpoint_id=tutorial_endpoint, client=gc)\n",
     "else:\n",
     "    # Create an Executor and initiate an auth flow if tokens are not available\n",
-    "    gce = Executor(endpoint_id=tutorial_endpoint)\n",
+    "    gc = Client(code_serialization_strategy=CombinedCode())\n",
+    "    gce = Executor(endpoint_id=tutorial_endpoint, client=gc)\n",
     "print(\"Executor : \", gce)"
    ]
   },

--- a/Compute_Introduction.ipynb
+++ b/Compute_Introduction.ipynb
@@ -162,6 +162,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Note**: It can take a few seconds to execute the first task submitted to the endpoint as it provisions resources."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jupyter
 minid>=2.0.1
 globus-sdk>=3
-globus-compute-sdk>=2.0.0
+globus-compute-sdk>=2.14.0


### PR DESCRIPTION
This updates a few things:
- Pins to 2.14.0 compute sdk. This makes the client use the new v3 submit route to enable use of our multi-user endpoint. This is needed for the latest version of the tutorial endpoint.
- Updates the notebook to use the credentials provided by the environment. This removes an additional login required in the notebook.
- Uses the CombineCode serializer. This removes an error caused by mismatched python versions. We can later remove this once the tutorial endpoint and jupyter environment are in sync with python versions.