### PR TITLE
Update Compute notebook to use existing client

### DIFF
--- a/Compute_Introduction.ipynb
+++ b/Compute_Introduction.ipynb
@@ -354,10 +354,7 @@
    },
    "outputs": [],
    "source": [
-    "from globus_compute_sdk import Client\n",
-    "gcc = Client()\n",
-    "\n",
-    "gcc.get_endpoint_status(tutorial_endpoint)"
+    "gc.get_endpoint_status(tutorial_endpoint)"
    ]
   }
  ],


### PR DESCRIPTION
Updates the final cell of the Compute notebook to use the already created Client, rather than creating a new one that requires an additional login flow.