### PR TITLE
fix: Platform_Introduction -- new API paths, make hub auth default

### DIFF
--- a/Platform_Introduction.ipynb
+++ b/Platform_Introduction.ipynb
@@ -94,7 +94,7 @@
     "import base64\n",
     "import pickle\n",
     "\n",
-    "USE_HUB_TOKENS = False\n",
+    "USE_HUB_TOKENS = True\n",
     "# The tokens are passed into the environment base64 encoded pickled Python dictionary \n",
     "# assigned to the GLOBUS_DATA variable. We'll grab the variable and unpack it.\n",
     "globus_env_data = os.getenv('GLOBUS_DATA')  # get the raw base64 encoded data\n",
@@ -799,7 +799,7 @@
     "\n",
     "# Fetch the local credential information from the GCS Manager\n",
     "gc = globus_sdk.GCSClient(tutorial_collection_info[\"gcs_manager_url\"], authorizer=tutorial_ep1_authorizer)\n",
-    "local_ep1_user_credential = gc.get(path=\"/api/user_credentials\").data[\"data\"][0]\n",
+    "local_ep1_user_credential = gc.get_user_credential_list()[\"data\"][0]\n",
     "print(f\"Found local user credential with username {local_ep1_user_credential['username']}\")"
    ]
   },
@@ -833,9 +833,8 @@
     "        \"mapped_collection_id\": host_collection_id,\n",
     "}\n",
     "\n",
-    "response = gc.post(\"/api/collections/\", data=guest_collection)\n",
-    "print(f\"{response['code']}: {response['message']}\")\n",
-    "guest_collection_id = response[\"data\"][0][\"id\"]"
+    "response = gc.create_collection(guest_collection)\n",
+    "guest_collection_id = response[\"id\"]"
    ]
   },
   {
@@ -1035,9 +1034,9 @@
     "        \"mapped_collection_id\": host_collection_id,\n",
     "}\n",
     "\n",
-    "response = gc.post(\"/api/collections/\", data=guest_collection)\n",
-    "guest_collection_id = response[\"data\"][0][\"id\"]\n",
-    "print(response)"
+    "response = gc.post(\"/collections/\", data=guest_collection)\n",
+    "print(response)\n",
+    "guest_collection_id = response[\"data\"][0][\"id\"]"
    ]
   },
   {
@@ -1055,7 +1054,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = gc.get(f\"/api/collections/{guest_collection_id}\",\n",
+    "response = gc.get(f\"/collections/{guest_collection_id}\",\n",
     "           query_params=dict(fields=\"id,display_name,description\"))\n",
     "print(response)"
    ]
@@ -1087,7 +1086,7 @@
     "    \"user_credential_id\": local_ep1_user_credential[\"id\"],\n",
     "    \"mapped_collection_id\": host_collection_id,\n",
     "}\n",
-    "response = gc.put(f\"/api/collections/{guest_collection_id}\", data=endpoint_update)\n",
+    "response = gc.put(f\"/collections/{guest_collection_id}\", data=endpoint_update)\n",
     "print(response)"
    ]
   },
@@ -1106,7 +1105,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = gc.delete(f\"/api/collections/{guest_collection_id}\")\n",
+    "response = gc.delete(f\"/collections/{guest_collection_id}\")\n",
     "print(response)"
    ]
   },
@@ -1136,7 +1135,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* The GCS API introduced some new API calls this month to relpace the old placeholders.
* This notebook now defaults to hub auth instead of native authentication