### PR TITLE
A few Compute intro notebook updates

### DIFF
--- a/Compute_Introduction.ipynb
+++ b/Compute_Introduction.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Globus Compute is a Function-as-a-Service (FaaS) platform that enables fire-and-forget execution of Python functions on one or more remote Globus Compute endpoints.\n",
     "\n",
-    "This tutorial is configured to use a tutorial endpoint hosted by the Globus Compute team. You can setup your own endpoint on resources to which you have access by following the [Globus Compute documentation](https://globus-compute.readthedocs.io/en/latest/endpoints.html). Globus Compute endpoints can be deployed on many cloud platforms, clusters with batch schedulers (e.g., Slurm, PBS), Kubernetes, or on a local PC. After configuring an endpoint you can use it in this tutorial by simply setting the `endpoint_id` below."
+    "This tutorial is configured to use a tutorial endpoint hosted by the Globus Compute team.  You can setup your own endpoint on resources to which you have access by following the [Globus Compute documentation](https://globus-compute.readthedocs.io/en/latest/endpoints/endpoints.html).  Globus Compute endpoints can be deployed on many cloud platforms, clusters with batch schedulers (e.g., Slurm, PBS), Kubernetes, or on a local PC.  After configuring an endpoint you can use it in this tutorial by simply setting the `endpoint_id` below."
    ]
   },
   {
@@ -19,7 +19,9 @@
     "\n",
     "The Globus Compute Python SDK provides programming abstractions for interacting with the Globus Compute service. Before running this tutorial you should first install the Globus Compute SDK as follows:\n",
     "\n",
-    "    $ pip install globus-compute-sdk\n",
+    "```console\n",
+    "$ pip install globus-compute-sdk\n",
+    "```\n",
     "\n",
     "The Globus Compute SDK exposes a `Client` and `Executor` for interacting with the Globus Compute service. In order to use Globus Compute, you must first authenticate using one of hundreds of supported identity provides (e.g., your institution, ORCID, or Google).  As part of the authentication process you must grant permission for Globus Compute to access your identity information (to retrieve your email address)."
    ]
@@ -31,16 +33,21 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import json\n",
     "import pickle\n",
     "import base64\n",
-    "import globus_sdk\n",
+    "from globus_sdk import AccessTokenAuthorizer\n",
     "from globus_sdk.scopes import AuthScopes\n",
     "\n",
     "from globus_compute_sdk import Client, Executor\n",
     "from globus_compute_sdk.serialize import CombinedCode\n",
     "from globus_compute_sdk.sdk.login_manager import AuthorizerLoginManager\n",
-    "from globus_compute_sdk.sdk.login_manager.manager import ComputeScopeBuilder"
+    "from globus_compute_sdk.sdk.login_manager.manager import ComputeScopeBuilder\n",
+    "\n",
+    "# For use within this Jupyter Notebook, these SDK imports are more complex\n",
+    "# than usual.  In other contexts (e.g., the command line, a stand alone\n",
+    "# script), it is often enough to import only the Executor:\n",
+    "#\n",
+    "# from globus_compute_sdk import Executor"
    ]
   },
   {
@@ -78,30 +85,35 @@
    },
    "outputs": [],
    "source": [
-    "# Try to get Globus Auth token data from the JupyterHub environment\n",
-    "globus_data_raw = os.getenv(\"GLOBUS_DATA\")\n",
+    "# Collect Globus Auth token data from the JupyterHub environment, if available\n",
+    "globus_data_raw = os.getenv('GLOBUS_DATA')\n",
+    "login_manager = None\n",
     "if globus_data_raw:\n",
-    "    tokens = pickle.loads(base64.b64decode(os.getenv('GLOBUS_DATA')))['tokens']\n",
+    "    # Environment has tokens we need; avoid a login flow by setting up the\n",
+    "    # requisite authorizers and data structures\n",
+    "    tokens = pickle.loads(base64.b64decode(globus_data_raw))['tokens']\n",
     "    \n",
     "    ComputeScopes = ComputeScopeBuilder()\n",
     "    \n",
     "    # Create Authorizers from the Compute and Auth tokens\n",
-    "    compute_auth = globus_sdk.AccessTokenAuthorizer(tokens[ComputeScopes.resource_server]['access_token'])\n",
-    "    openid_auth = globus_sdk.AccessTokenAuthorizer(tokens['auth.globus.org']['access_token'])\n",
+    "    compute_auth = AccessTokenAuthorizer(tokens[ComputeScopes.resource_server]['access_token'])\n",
+    "    openid_auth = AccessTokenAuthorizer(tokens['auth.globus.org']['access_token'])\n",
     "    \n",
     "    # Create a Compute Client from these authorizers\n",
-    "    compute_login_manager = AuthorizerLoginManager(\n",
-    "        authorizers={ComputeScopes.resource_server: compute_auth,\n",
-    "                     AuthScopes.resource_server: openid_auth}\n",
+    "    login_manager = AuthorizerLoginManager(\n",
+    "        authorizers={\n",
+    "            ComputeScopes.resource_server: compute_auth,\n",
+    "            AuthScopes.resource_server: openid_auth,\n",
+    "        }\n",
     "    )\n",
-    "    compute_login_manager.ensure_logged_in()\n",
-    "    gc = Client(login_manager=compute_login_manager, code_serialization_strategy=CombinedCode())\n",
-    "    gce = Executor(endpoint_id=tutorial_endpoint, client=gc)\n",
-    "else:\n",
-    "    # Create an Executor and initiate an auth flow if tokens are not available\n",
-    "    gc = Client(code_serialization_strategy=CombinedCode())\n",
-    "    gce = Executor(endpoint_id=tutorial_endpoint, client=gc)\n",
-    "print(\"Executor : \", gce)"
+    "    login_manager.ensure_logged_in()\n",
+    "\n",
+    "# Only necessary because reusing the provided Jupyter environment; other use-cases\n",
+    "# can simply use the Executor directly, with no need to customize the Client:\n",
+    "#     gce = Executor(endpoint_id=your_endpoint_id)\n",
+    "gc = Client(login_manager=login_manager, code_serialization_strategy=CombinedCode())\n",
+    "gce = Executor(endpoint_id=tutorial_endpoint, client=gc)\n",
+    "print('Executor : ', gce)"
    ]
   },
   {
@@ -128,12 +140,12 @@
    "outputs": [],
    "source": [
     "# Define the function for remote execution\n",
-    "def hello_world():\n",
-    "    return \"Hello World!\"\n",
+    "def hello_name(name: str):\n",
+    "    return f'Hello, {name}!'\n",
     "\n",
-    "future = gce.submit(hello_world)\n",
+    "future = gce.submit(hello_name, 'wonderful person')\n",
     "\n",
-    "print(\"Submit returned: \", future)"
+    "print('Submit returned immediately (no result yet): ', future)"
    ]
   },
   {
@@ -142,7 +154,7 @@
    "source": [
     "### Getting results\n",
     "\n",
-    "When you `submit` a function for execution (called a `task`), the executor will return an instance of `ComputeFuture` in lieu of the result from the function.  Futures are a common way to reference asynchronous tasks, enabling you to interrogate the future to find the status, results, exceptions, etc. without blocking to wait for results.\n",
+    "When you `submit()` a function for execution (called a `task`), the executor will return an instance of `ComputeFuture` in lieu of the result from the function.  Futures are a common way to reference asynchronous tasks, enabling you to interrogate the future to find the status, results, exceptions, etc. without blocking to wait for results.\n",
     "\n",
     "`ComputeFuture`s returned from the `Executor` can be used in the following ways:\n",
     "* `future.done()` is a non-blocking call that returns a boolean that indicates whether the task is finished.\n",
@@ -165,7 +177,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **Note**: It can take a few seconds to execute the first task submitted to the endpoint as it provisions resources."
+    "> **Note**: It may take a few seconds to execute the first task submitted to the endpoint as it provisions resources."
    ]
   },
   {
@@ -187,7 +199,7 @@
    "source": [
     "### Catching exceptions\n",
     "\n",
-    "When a task fails and you try to get its result, the `future` will raise an exception. In the following example, the `ZeroDivisionError` exception is raised when `future.result()` is called."
+    "When a task fails and you try to get its result, the `future` will raise an exception. In the following example, the `ZeroDivisionError` exception is raised when `future.result()` is called:"
    ]
   },
   {
@@ -206,7 +218,7 @@
     "try:\n",
     "    future.result()\n",
     "except Exception as exc:\n",
-    "    print(\"Globus Compute returned an exception: \", exc)"
+    "    print('Globus Compute returned an exception: ', exc)"
    ]
   },
   {
@@ -217,9 +229,9 @@
     "\n",
     "Globus Compute supports registration and execution of functions with arbitrary arguments and returned parameters. Globus Compute will serialize any `*args` and `**kwargs` when executing a function and it will serialize any return parameters or exceptions.\n",
     "\n",
-    "Note: Globus Compute uses standard Python serilaization libraries (i.e., Dill). It also limits the size of input arguments and returned parameters to 10 MB. For larger input or output data we suggest using Globus.\n",
+    "Note: Globus Compute uses standard Python serialization libraries (i.e., [`dill`](https://dill.readthedocs.io/en/latest/index.html)).  It also limits the size of input arguments and returned parameters to 10 MB.  For larger input or output data we suggest using [Globus Connect](https://www.globus.org/globus-connect-personal).\n",
     "\n",
-    "The following example shows a function that computes the sum of a list of input arguments."
+    "The following example shows a function that computes the sum of a list of input arguments:"
    ]
   },
   {
@@ -234,7 +246,7 @@
     "    return a + b\n",
     "\n",
     "future = gce.submit(get_sum, 40, 2)\n",
-    "print(f\"40 + 2 = {future.result()}\")"
+    "print(f'40 + 2 = {future.result()}')"
    ]
   },
   {
@@ -243,7 +255,7 @@
    "source": [
     "## Functions with dependencies\n",
     "\n",
-    "In order to execute a function on a remote endpoint, Globus Compute requires that functions explictly state all dependencies within the function body. It also requires that any dependencies (e.g., libraries, modules) are available on the endpoint on which the function will execute.  For example, in the following function, we explicitly import the datetime module."
+    "In order to execute a function on a remote endpoint, Globus Compute requires that functions explictly state all dependencies within the function body.  It also requires that any dependencies (e.g., libraries, modules) are available on the endpoint on which the function will execute.  For example, in the following function, we explicitly import `date` from the `datetime` module:"
    ]
   },
   {
@@ -260,7 +272,25 @@
     "\n",
     "future = gce.submit(get_date)\n",
     "\n",
-    "print(\"Date fetched from endpoint: \", future.result())"
+    "print('Date fetched from endpoint: ', future.result())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The result of a function is not simply a string or a number.  The endpoint (\"remote-side\") serializes whatever the function returns, and the SDK (\"local-side\") performs the opposite operation.  Strings, integers, and floats transfer from remote to local, and so do any objects that can be serialized.  Note, for example, the type of the last result:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note the data type of the result; it's not a raw string or number:\n",
+    "print('Result data type:', type(future.result()))\n",
+    "print('The week number of the year:', future.result().isocalendar().week)"
    ]
   },
   {
@@ -269,7 +299,9 @@
    "source": [
     "## Calling external applications\n",
     "\n",
-    "While Globus Compute is designed to execute Python functions, you can easily invoke external applications that are accessible on the remote endpoint. For example, the following function calls the Linux `echo` command."
+    "While Globus Compute is designed to execute Python functions, you can easily invoke external applications that are accessible on the remote endpoint.  For example, the following function runs anything given as an argument in a shell (e.g., `sh`).\n",
+    "\n",
+    "> **Note**: This is only an example to show running a remote shell script.  We recommend using [ShellFunction](https://globus-compute.readthedocs.io/en/latest/sdk/executor_user_guide.html#shell-functions) for most applications."
    ]
   },
   {
@@ -281,13 +313,50 @@
    },
    "outputs": [],
    "source": [
-    "def echo(name):\n",
-    "    import os\n",
-    "    return os.popen(\"echo Hello {}, your home is at $HOME\".format(name)).read()\n",
+    "from subprocess import CompletedProcess\n",
     "\n",
-    "future = gce.submit(echo, \"World\")\n",
+    "def runsh(cmd):\n",
+    "    # This function is run on the *remote* host\n",
+    "    from subprocess import run, PIPE, STDOUT\n",
+    "    return run(cmd, shell=True, stdout=PIPE, stderr=STDOUT)\n",
     "\n",
-    "print(\"Echo output: \", future.result())"
+    "def run_and_print(cmd):\n",
+    "    # A formatting function; runs locally, but it sends the `cmd` upstream\n",
+    "    # to runsh via gce.submit()\n",
+    "    future = gce.submit(runsh, cmd)\n",
+    "    proc_result = future.result()\n",
+    "\n",
+    "    assert isinstance(proc_result, CompletedProcess), '*complex, remote* objects serialized; recreated locally by SDK'\n",
+    "\n",
+    "    print('\\n' + '=' * 80)\n",
+    "    print(f'Return code: {proc_result.returncode}')\n",
+    "    print(f'\\n$ {proc_result.args}\\n{proc_result.stdout.decode(errors=\"backslashreplace\")}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, a simple command to \"prove the point\"\n",
+    "cmd = '''/bin/echo \"The \\\\$USER environment variable is '$USER'\"'''\n",
+    "run_and_print(cmd)\n",
+    "\n",
+    "# Now for a longer, compound statement script\n",
+    "cmd = '''\n",
+    "/bin/echo -e \"\\\\n---------- Environment variables ----------\"\n",
+    "set\n",
+    "/bin/echo -e \"\\\\n---------- Host kernel info ---------------\"\n",
+    "uname -a\n",
+    "/bin/echo -e \"\\\\n---------- Host memory --------------------\"\n",
+    "free -m\n",
+    "'''.strip().replace('\\n', '; ')\n",
+    "run_and_print(cmd)\n",
+    "\n",
+    "# What time does the remote-side think it is?\n",
+    "cmd = '/bin/date'\n",
+    "run_and_print(cmd)"
    ]
   },
   {
@@ -297,8 +366,7 @@
     "## Running functions many times\n",
     "\n",
     "One of the strengths of Globus Compute is the ease by which you can run functions many times, perhaps with different input arguments.  The following example shows how you can use the Monte Carlo method to estimate pi.\n",
-    "\n",
-    "Specifically, if a circle with radius $r$ is inscribed inside a square with side length $2r$, the area of the circle is $\\pi r^2$ and the area of the square is $(2r)^2$. Thus, if $N$ uniformly-distributed points are dropped at random locations within the square, approximately $N\\pi/4$ will be inside the circle and therfore we can estimate the value of $\\pi$.\n"
+    "Specifically, if a circle with radius $r$ is inscribed inside a square with side length $2r$, the area of the circle is $\\pi r^2$ and the area of the square is $(2r)^2$. Thus, if $N$ uniformly-distributed points are dropped at random locations within the square, approximately $N\\pi/4$ will be inside the circle and therefore we can estimate the value of $\\pi$.\n"
    ]
   },
   {
@@ -309,7 +377,7 @@
    },
    "outputs": [],
    "source": [
-    "import time\n",
+    "import statistics\n",
     "\n",
     "# function that estimates pi by placing points in a box\n",
     "def pi(num_points):\n",
@@ -323,18 +391,20 @@
     "    return (inside*4 / num_points)\n",
     "\n",
     "\n",
-    "# execute the function 3 times \n",
-    "estimates = []\n",
-    "for i in range(3):\n",
-    "    estimates.append(gce.submit(pi, \n",
-    "                               10**5))\n",
+    "# execute the function N times \n",
+    "N = 100\n",
+    "estimates = [\n",
+    "    gce.submit(pi, 10**5)\n",
+    "    for _ in range(N)\n",
+    "]\n",
     "\n",
     "# get the results and calculate the total\n",
-    "total = [future.result() for future in estimates]\n",
+    "results = [future.result() for future in estimates]\n",
     "\n",
     "# print the results\n",
-    "print(\"Estimates: {}\".format(total))\n",
-    "print(\"Average: {:.5f}\".format(sum(total)/len(estimates)))"
+    "print('Estimates: [{:.3f}, {:.3f}, {:.3f}, ..., {:.3f}]'.format(*results[:3], results[-1]))\n",
+    "print(f'   Mean: {sum(results)/len(results):.5f}')\n",
+    "print(f'Std Dev: {statistics.stdev(results):.5f}')"
    ]
   },
   {
@@ -374,7 +444,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Touch up a few spelling mistakes (e.g., `serilaization`)

- Linkify some inline text (e.g., dill, Globus Connect), and update other links
  (e.g., Compute documentation)

- Update the 'external applications' cell to be slightly more general, and add
  two more examples to showcase both what can be done and what Compute offers

- Show running the final example more times (3 -> 100), and show a standard
  deviation of the sample

- Prefer single-quotes in the code cells (where appropriate) to make reading
  the serialized JSON notebook code slightly easier
