### PR TITLE
Add a simple "form" for running functions

### DIFF
--- a/Compute_Run_Task.ipynb
+++ b/Compute_Run_Task.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b8eed15c-4337-4d30-8dd0-d53ce4e1cd3a",
+   "metadata": {},
+   "source": [
+    "# Run Compute Tasks\n",
+    "\n",
+    "Instructions:\n",
+    "\n",
+    "1. Replace the contents of the variables in the following cell\n",
+    "2. If your function requires arguments, set `f_args` and `f_kwargs` in the cell after next\n",
+    "3. Run the final cell and await your results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85b662b0-30ec-4020-9972-9cd8a988a403",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "globus_compute_tutorial_endpoint_id = \"4b116d3c-1703-4f8f-9f6f-39921e5864df\"\n",
+    "your_endpoint_id = \"<put_your_ep_uuid_here>\"\n",
+    "\n",
+    "endpoint_id = globus_compute_tutorial_endpoint_id  # Update which endpoint_id to use\n",
+    "\n",
+    "# Replace this string with the function to call within the module ...\n",
+    "module_entrypoint = \"pretty_print_peek_at_host\"\n",
+    "\n",
+    "module_desc = \"[optional] describe the function's intention or other useful-to-you-later details\"\n",
+    "\n",
+    "# ... and define that module within this string.  (i.e. replace the content with your code)\n",
+    "python_module_text = \"\"\"\n",
+    "import os\n",
+    "import typing as t\n",
+    "\n",
+    "import psutil\n",
+    "\n",
+    "def row_by_row(data: t.Iterable[tuple[t.Any, t.Any]]) -> str:\n",
+    "    lines = []\n",
+    "    for ndx, (key, val) in enumerate(data):\n",
+    "        c = ndx % 2 and \"\\033[92;1m\" or \"\\033[93;1m\"\n",
+    "        lines.append(f\"{c}{key:>19}: {val}\\033[0m\")\n",
+    "    return \"\\\\n\".join(lines)\n",
+    "\n",
+    "\n",
+    "def peek_at_host() -> dict[str, t.Any]:\n",
+    "    return {\n",
+    "      \"core_count\": os.cpu_count(),\n",
+    "      \"physical_core_count\": psutil.cpu_count(logical=False),\n",
+    "      \"cores_available\": os.sched_getaffinity(0),\n",
+    "      \"virtmem\": psutil.virtual_memory(),\n",
+    "      \"uname\": os.uname(),\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def pretty_print_peek_at_host() -> str:\n",
+    "    return row_by_row(peek_at_host().items())\n",
+    "\"\"\"\n",
+    "assert f\"def {module_entrypoint}\" in python_module_text, \"Entrypoint not found!\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8f0e4eb-3bdb-4882-a1d7-b80fd6952e20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If the function needs arguments, specify them here\n",
+    "f_args = ()\n",
+    "f_kwargs = {}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e5c70c4-3688-4bf4-be0d-abe80b6c1ac8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from globus_compute_sdk import Executor\n",
+    "\n",
+    "with Executor(endpoint_id) as ex:\n",
+    "    func_id = ex.register_source_code(python_module_text, module_entrypoint, description=module_desc)\n",
+    "    future = ex.submit_to_registered_function(func_id, args=f_args, kwargs=f_kwargs)\n",
+    "    print(\"Task enqueued, awaiting submission.\")\n",
+    "    try:\n",
+    "        while not future.task_id:\n",
+    "            time.sleep(0.1)\n",
+    "        print(f\"Task submitted ({future.task_id}); awaiting result:\")\n",
+    "        print(future.result())\n",
+    "    except Exception as e:\n",
+    "        print(\"  \\033[91;1mOh no!  Task failed.  The reported exception was\\033[0m:\")\n",
+    "        print(str(e))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71658d2e-3eab-468e-9b5c-44b5f400ca29",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Reading through the Compute tutorial is helpful, but sometimes people just want to run a task.  Using `register_source_code`, this 4-cell notebook attempts to provide a simple "form-like" interaction for running a Compute task.  This may also serve as a precursor to getting a form for running Compute functions through the WebUI at app.globus.org.